### PR TITLE
Update to accept nodejs6.10 as valid runtime variable

### DIFF
--- a/src/ServerlessValidator.hs
+++ b/src/ServerlessValidator.hs
@@ -231,6 +231,9 @@ data Runtime
 
 
 mkRuntime :: Text -> Either ErrorMsg Runtime
+mkRuntime "nodejs6.10" =
+  Right NodeJs
+
 mkRuntime "nodejs4.3" =
   Right NodeJs
 
@@ -241,7 +244,7 @@ mkRuntime "python2.7" =
   Right Python
 
 mkRuntime unknown =
-  Left $ "Unsupported runtime '" <> unknown <> "'. Choose one among: 'nodejs4.3', 'java8', 'python2.8'"
+  Left $ "Unsupported runtime '" <> unknown <> "'. Choose one among: 'nodejs6.10', 'nodejs4.3', 'java8', 'python2.8'"
 
 
 instance FromJSON Runtime where

--- a/test/ServerlessValidatorSpec.hs
+++ b/test/ServerlessValidatorSpec.hs
@@ -66,6 +66,7 @@ testRuntimeValidation =
     decode "java8" `shouldBe` Right S.Java
     decode "python2.7" `shouldBe` Right S.Python
     decode "nodejs4.3" `shouldBe` Right S.NodeJs
+    decode "nodejs6.10" `shouldBe` Right S.NodeJs
     decode "foobar" `shouldSatisfy` isLeft
       where
         decode rt =


### PR DESCRIPTION
Serverless suggests default operation with nodejs6.10, the validator
now no longer throws on this issue.